### PR TITLE
zéros superflus dans urls et ancres, espace devise non attendu, possibilité de sous-menu

### DIFF
--- a/config.php
+++ b/config.php
@@ -75,7 +75,7 @@ if(!empty($_POST)){
  $plxPlugin->setParam('devise', $_POST['devise'], 'string');
  $plxPlugin->setParam('commercant_postcode', $_POST['commercant_postcode'], 'string');
  $plxPlugin->setParam('menu_position', $_POST['menu_position'], 'numeric');
-
+ $plxPlugin->setParam('submenu', trim($_POST['submenu']), 'string');
  $afficheCategoriesMenu = isset($_POST['afficheCategoriesMenu']) ? "" : "non";
  $plxPlugin->setParam('afficheCategoriesMenu', $afficheCategoriesMenu, 'string');
  $plxPlugin->setParam('afficheLienPanierTop', isset($_POST['afficheLienPanierTop'])?'1':'0', 'numeric');
@@ -143,6 +143,7 @@ $var['commercant_postcode'] = $plxPlugin->getParam('commercant_postcode')=='' ? 
 $var['commercant_city'] = $plxPlugin->getParam('commercant_city')=='' ? 'Dun' : $plxPlugin->getParam('commercant_city');
 $var['devise'] = $plxPlugin->getParam('devise')=='' ? ' €' : $plxPlugin->getParam('devise');
 $var['menu_position'] = $plxPlugin->getParam('menu_position')=='' ? 3 : $plxPlugin->getParam('menu_position');
+$var['submenu'] = $plxPlugin->getParam('submenu')=='' ? '' : $plxPlugin->getParam('submenu');
 $var['afficheCategoriesMenu'] = $plxPlugin->getParam('afficheCategoriesMenu');
 $var['afficheLienPanierTop'] = $plxPlugin->getParam('afficheLienPanierTop');
 $var["affPanier"] = ("" === $plxPlugin->getParam("affPanier")) ? current(array_keys($tabAffPanier)) : $plxPlugin->getParam("affPanier");
@@ -429,6 +430,14 @@ if ($array = $files->query('/^static(-[a-z0-9-_]+)?.php$/')) {
    </div>
    <div class="col sml-12 med-7">
     <?php plxUtils::printInput('menu_position',$var['menu_position'],'number','100-120') ?>
+   </div>
+  </div>
+  <div class="grid">
+   <div class="col sml-12 med-5 label-centered">
+    <label for="id_submenu"><?php $plxPlugin->lang('L_CONFIG_SUBMENU') ?>&nbsp;:</label>
+   </div>
+   <div class="col sml-12 med-7">
+    <?php plxUtils::printInput('submenu',$var['submenu'],'text','100-120') ?>
    </div>
   </div>
   <div class="scrollable-table">

--- a/datatables.js.php
+++ b/datatables.js.php
@@ -1,4 +1,4 @@
-<script type="text/javascript" language="javascript" src="//code.jquery.com/jquery-1.12.4.js"></script>
+<script type="text/javascript" language="javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script type="text/javascript" language="javascript" src="https://cdn.datatables.net/1.10.13/js/jquery.dataTables.min.js"></script>
 <script type="text/javascript" language="javascript" src="//cdn.datatables.net/responsive/1.0.0/js/dataTables.responsive.min.js"></script>
 <script type="text/javascript" class="init">

--- a/lang/fr.php
+++ b/lang/fr.php
@@ -141,6 +141,7 @@ $LANG = array(
 
 'L_CONFIG_MENU_TITLE'               => 'Configuration menu et tactique du cookie client',
 'L_CONFIG_MENU_POSITION'            => 'Position dans le menu des catégories et pages fixes (panier)',
+'L_CONFIG_SUBMENU'                  => 'Afficher ( case vide = non ) les catégories et le panier dans un sous-menu nommé',
 
 'L_CONFIG_PAGE'                     => 'Configuration des pages',
 

--- a/modeles/espacePublic/boucle/boutonPanier.php
+++ b/modeles/espacePublic/boucle/boutonPanier.php
@@ -25,7 +25,7 @@ if (isset($_SESSION["plxMyShop"]["prods"][$d["k"]])){
 
 $nbProdtype = (count($d["pileModeles"]) === 1)?'hidden':'number'; //dansShortcode = hidden
 ?>
-<form action="#prod<?php echo $d["k"]; ?>" method="POST" id="FormAddProd<?php echo $d["k"]; ?>" class="formulaireAjoutProduit" onsubmit="chngNbProd('<?php echo $d["k"]; ?>',true);">
+<form action="#prod<?php echo intval($d["k"]); ?>" method="POST" id="FormAddProd<?php echo $d["k"]; ?>" class="formulaireAjoutProduit" onsubmit="chngNbProd('<?php echo $d["k"]; ?>',true);">
  <input type="hidden" name="idP" value="<?php echo htmlspecialchars($d["k"]);?>">
  <input type="<?php echo $nbProdtype; ?>" name="nb" value="<?php echo $prodsPnr; ?>" min="<?php echo $minPnr; ?>" id="nbProd<?php echo $d["k"]; ?>" onchange="chngNbProd('<?php echo $d["k"]; ?>',false);" data-o="<?php echo $prodsPnr; ?>" />
  <input class="<?php echo $classPnrBtn; ?>" type="submit" id="addProd<?php echo $d["k"]; ?>" name="ajouterProduit" value="<?php echo $txtPnrBtn; ?>" />

--- a/modeles/espacePublic/boucle/produitRubrique.php
+++ b/modeles/espacePublic/boucle/produitRubrique.php
@@ -5,7 +5,7 @@ version :
 */
 $v = $this->aProds[$d["k"]];
 ?>
-<div id="prod<?php echo $d["k"]; ?>" class="lproduct_content" align="center">
+<div id="prod<?php echo intval($d["k"]); ?>" class="lproduct_content" align="center">
  <header>
   <h1 class="product_poidg"><a href="<?php echo $this->productRUrl($d["k"]); ?>" ><?php echo $v['name']; ?></a></h1>
   <?php echo $v['image'] != ''

--- a/modeles/espacePublic/produit.php
+++ b/modeles/espacePublic/produit.php
@@ -6,7 +6,7 @@ version :
 $plxPlugin = $d["plxPlugin"];
 $produit = $plxPlugin->aProds[$plxPlugin->productNumber()];
 if (is_array($plxPlugin->productGroupTitle())) {
-echo '<div id="prod'.$plxPlugin->productNumber().'"></div>';
+echo '<div id="prod'.intval($plxPlugin->productNumber()).'"></div>';
  $i=0;
  foreach($plxPlugin->productGroupTitle() as $key => $value) {
   echo ($i>0?',':'').'<a href="'.$plxPlugin->productRUrl($key).'">'.$value.'</a>';

--- a/plxMyShop.php
+++ b/plxMyShop.php
@@ -717,7 +717,7 @@ for($i=1;$i<=11;$i++){
      echo '<?php
      echo "\n";
      echo "\t<url>\n";
-     echo "\t\t<loc>".$plxMotor->urlRewrite("?'.$this->lang.'product'.$key.'/'.$value['url'].'")."</loc>\n";
+     echo "\t\t<loc>".$plxMotor->urlRewrite("?'.$this->lang.'product'.intval($key).'/'.$value['url'].'")."</loc>\n";
      echo "\t\t<lastmod>'.date('Y-m-d').'</lastmod>\n";
      echo "\t\t<changefreq>daily</changefreq>\n";
      echo "\t\t<priority>0.8</priority>\n";

--- a/plxMyShop.php
+++ b/plxMyShop.php
@@ -1276,6 +1276,13 @@ for($i=1;$i<=11;$i++){
   * @author David.L
   **/
  public function plxShowStaticListEnd(){
+  # initialise submenu
+  $submenu = ($this->getParam('submenu')!=''?true:false);
+  $submenuCategories = '';
+  $submenuPanier = '';
+  $active = ("product" === $this->plxMotor->mode?'active':'noactive');
+  $active = ("boutique" === $this->plxMotor->mode?'active':$active);
+
   $positionMenu = $this->getParam('menu_position') - 1;
   if (in_array(
     $this->getParam("affPanier")
@@ -1300,11 +1307,10 @@ for($i=1;$i<=11;$i++){
 
    // Afficher la page panier dans le menu ?
    if ($this->getParam("affichePanierMenu")!="non") {
-    echo "<?php";
-    echo " array_splice(\$menus, $positionMenu, 0";
-    echo "  , '<li><a class=\"static $classeCss\" href=\"$lienPanier\" title=\"' . htmlspecialchars('$titreProtege') . '\">$titreProtege</a></li>'";
-    echo " );";
-    echo "?>";
+    $submenuPanier = "<li><a class=\"static $classeCss\" href=\"$lienPanier\" title=\"' . htmlspecialchars('$titreProtege') . '\">$titreProtege</a></li>";
+    if (!$submenu){
+     echo "<?php array_splice(\$menus, $positionMenu, 0, '$submenuPanier'); ?>";
+    }
    }
   }
 
@@ -1330,13 +1336,17 @@ for($i=1;$i<=11;$i++){
 
      $classeCss = $categorieSelectionnee ? "active" : "noactive";
      $lien = $this->plxMotor->urlRewrite('?'.$this->lang."product$k/{$v["url"]}");
-
-     echo "<?php";
-     echo " array_splice(\$menus, $positionMenu, 0";
-     echo "  , '<li><a class=\"static $classeCss\" href=\"$lien\" title=\"' . htmlspecialchars('$nomProtege') . '\">$nomProtege</a></li>'";
-     echo " );";
-     echo "?>";
+     $submenuTemp = "<li><a class=\"static $classeCss\" href=\"$lien\" title=\"' . htmlspecialchars('$nomProtege') . '\">$nomProtege</a></li>";
+	 $submenuCategories .= $submenuTemp;
+     if (!$submenu){
+      echo "<?php array_splice(\$menus, $positionMenu, 0, '$submenuTemp'); ?>";
+     }
     }
+   }
+   if ($submenu){
+    echo "<?php array_splice(\$menus, $positionMenu, 0,";
+    echo " '<li><span class=\"static group $active\">".$this->getParam('submenu')."</span><ul>$submenuCategories$submenuPanier</ul></li>' ";
+    echo " ) ?>";
    }
   } // FIN if ajout du menu pour accèder aux rubriques
  } // FIN public function plxShowStaticListEnd(){

--- a/plxMyShop.php
+++ b/plxMyShop.php
@@ -1605,7 +1605,7 @@ $message
    , $this->getlang("L_SEPARATEUR_MILLIERS")
   );
   if ( $this->getParam('position_devise') == "before" ){
-   $pos_price = trim($this->getParam('devise')).'&nbsp;'.$price;
+   $pos_price = trim($this->getParam('devise')).''.$price;
   } elseif ( $this->getParam('position_devise') == "after" ){
    $pos_price = $price.'&nbsp;'.trim($this->getParam('devise'));
   }

--- a/plxMyShop.php
+++ b/plxMyShop.php
@@ -1070,7 +1070,7 @@ for($i=1;$i<=11;$i++){
   **/
  public function productUrl($type='relatif'){
   # Recupération ID URL
-  $productId = $this->productId();
+  $productId = intval($this->productId());
   $productIdFill = str_pad($productId,3,'0',STR_PAD_LEFT);
   if(!empty($productId) AND isset($this->aProds[ $productIdFill ]))
    echo $this->urlRewrite('?'.$this->lang.'product'.$productId.'/'.$this->aProds[ $productIdFill ]['url']);
@@ -1322,6 +1322,7 @@ for($i=1;$i<=11;$i++){
    foreach(array_reverse($this->aProds) as $k=>$v){
     if ($v['menu']!='non' && $v['menu']!=''){
      $nomProtege = self::nomProtege($v['name']);
+     $k = intval($k);
      $categorieSelectionnee = (
        ("product" === $this->plxMotor->mode)
       && ("product$k/{$v["url"]}" === $this->plxMotor->get)


### PR DESCRIPTION
Les urls et ancres deviennent /productNUM/titre au lieu de /product00NUM/titre
Permettre de ne pas avoir d'espace entre la devise et le prix quand cette même devise est placée avant le prix.
Permettre d'afficher les catégories et le panier dans un sous-menu